### PR TITLE
Add DefaultAuthorizationHandlerProvider in order to enable use of role-based authorization.

### DIFF
--- a/src/AzureFunctions.Extensions.OpenIDConnect.Tests/AuthorizationServiceShould.cs
+++ b/src/AzureFunctions.Extensions.OpenIDConnect.Tests/AuthorizationServiceShould.cs
@@ -24,8 +24,9 @@ namespace AzureFunctions.Extensions.OpenIDConnect.Tests
             // Arrange
             var policyName = "my policy";
             var localeClaim = new Claim(claimType, claimValue);
-             
-            var collection = ServiceCollectionFixture.MinimalAzFunctionsServices();
+
+            var collection = ServiceCollectionFixture.MinimalAzFunctionsServices()
+                            .WithClaimsAuthorizationHandler(claimType, new[] { claimRequiredValue });
 
             collection.AddOpenIDConnect(builder =>
             {

--- a/src/AzureFunctions.Extensions.OpenIDConnect.Tests/ServiceCollectionFixture.cs
+++ b/src/AzureFunctions.Extensions.OpenIDConnect.Tests/ServiceCollectionFixture.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using System.Collections.Generic;
 
 namespace AzureFunctions.Extensions.OpenIDConnect.Tests
 {
@@ -22,6 +24,12 @@ namespace AzureFunctions.Extensions.OpenIDConnect.Tests
             var logger = Substitute.For<ILogger<DefaultAuthorizationService>>();
             collection.AddSingleton<ILogger<DefaultAuthorizationService>>(logger);
 
+            return collection;
+        }
+
+        public static ServiceCollection WithClaimsAuthorizationHandler(this ServiceCollection collection, string claimType, IEnumerable<string> allowedValues)
+        {
+            collection.AddSingleton<IAuthorizationHandler>(new ClaimsAuthorizationRequirement(claimType, allowedValues));
             return collection;
         }
     }

--- a/src/AzureFunctions.Extensions.OpenIDConnect/Configuration/ServicesConfigurationExtensions.cs
+++ b/src/AzureFunctions.Extensions.OpenIDConnect/Configuration/ServicesConfigurationExtensions.cs
@@ -50,6 +50,7 @@ namespace AzureFunctions.Extensions.OpenIDConnect.Configuration
             services.AddSingleton<IFunctionFilter, AuthorizeFilter>();
             services.AddSingleton<IAuthorizationService, DefaultAuthorizationService>();
             services.AddSingleton<IAuthorizationPolicyProvider, DefaultAuthorizationPolicyProvider>();
+            services.AddSingleton<IAuthorizationHandlerProvider, DefaultAuthorizationHandlerProvider>();
         }
     }
 }


### PR DESCRIPTION
Hello,

In order to make use of role-based authorization I need to add the DefaultAuthorizationHandlerProvider.

Otherwise the default Role AuthorizationHandler is not properly injected in the AuthorizationService (through the DefaultAuthorizationHandlerProvider).

Regards
