### PR TITLE
Correct MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2021 Fabrice Michellonet
+Copyright (c) 2020 ASP.NET Monsters
+Copyright (c) 2020 Bryan Knox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Thanks for (indirectly) forking my https://github.com/bryanknox/AzureFunctionsOpenIDConnectAuthSample repo, and I hope your NuGet package is well received.

This is just a correction to the copyright notices in the LICNSE file so that they comply with the MIT license.

In an MIT license, the copyright notice(s) from the forked repo need to be retained as-is, per the text in the MIT License. The copyright notice for this newer repo is then added before the others.

Since this repo was forked from https://github.com/AspNetMonsters/AzureFunctions.OidcAuthentication, I included the copyright notice from that repo as well as the copyright from my https://github.com/bryanknox/AzureFunctionsOpenIDConnectAuthSample repo, which ASP.NET Monsters forked from. And I created a similar pull request in the ASP.NET Monsters' repo.
See https://github.com/AspNetMonsters/AzureFunctions.OidcAuthentication/pull/8

Kind regards.
