### PR TITLE
Set ClaimsPrincipal 

### DIFF
--- a/src/AzureFunctions.Extensions.OpenIDConnect.Isolated/AuthorizationFunctionMiddleware.cs
+++ b/src/AzureFunctions.Extensions.OpenIDConnect.Isolated/AuthorizationFunctionMiddleware.cs
@@ -49,7 +49,9 @@ namespace AzureFunctions.Extensions.OpenIDConnect.Isolated
                     Unauthorized(functionContextAccessor, requestData);
                     return;
                 }
-            
+
+                executingContext.Items.Add(HttpRequestDataExtensions.UserKey, authenticationResult.User);
+
                 var attribute = _routeGuardian.GetAuthorizationConfiguration(executingContext.FunctionDefinition.Name);
                 var requirements = _requirementsRetriever.ForAttribute(attribute);
 

--- a/src/AzureFunctions.Extensions.OpenIDConnect.Isolated/HttpRequestDataExtensions.cs
+++ b/src/AzureFunctions.Extensions.OpenIDConnect.Isolated/HttpRequestDataExtensions.cs
@@ -1,0 +1,17 @@
+using System.Security.Claims;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace AzureFunctions.Extensions.OpenIDConnect.Isolated;
+
+public static class HttpRequestDataExtensions
+{
+    internal const string UserKey = "OpenIDConnect_principal";
+    public static ClaimsPrincipal User(this HttpRequestData httpRequestData)
+    {
+        if (httpRequestData.FunctionContext.Items.TryGetValue(UserKey, out var user))
+        {
+            return user as ClaimsPrincipal;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
For Isolated host the middleware now sets the ClaimPrincipal of the currently authenticated user.
